### PR TITLE
Update labels for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -38,6 +38,8 @@ updates:
           - '*'
     labels:
       - 'update'
+      - 'dependencies'
+      - 'docker'
 
   - package-ecosystem: 'docker'
     # Look for a `Dockerfile` in the listed directories
@@ -51,6 +53,8 @@ updates:
       interval: 'daily'
     labels:
       - 'update'
+      - 'dependencies'
+      - 'docker'
 
   # Enable version updates for Python/Pip - Production
   - package-ecosystem: 'pip'
@@ -67,6 +71,8 @@ updates:
           - 'patch'
     labels:
       - 'update'
+      - 'dependencies'
+      - 'python'
 
   # Update npm packages
   - package-ecosystem: 'npm'
@@ -80,3 +86,5 @@ updates:
           - 'patch'
     labels:
       - 'update'
+      - 'dependencies'
+      - 'javascript'


### PR DESCRIPTION
This pull request updates the `.github/dependabot.yml` configuration file to add more specific labels for dependency updates across various ecosystems. The changes enhance the categorization of updates, making it easier to track and manage them.

Label additions by ecosystem:

* **Docker**: Added `dependencies` and `docker` labels for Docker updates. [[1]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R41-R42) [[2]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R56-R57)
* **Python**: Added `dependencies` and `python` labels for Python/Pip updates.
* **JavaScript**: Added `dependencies` and `javascript` labels for npm updates.