### PR TITLE
100% coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,12 @@
 # OpServ
 
-Operations Server for Gaming Comunities!
+Operations Server for Gaming Communities!
+
+[![Django](https://img.shields.io/badge/django-4.2.9-blue.svg?logo=django)](https://www.djangoproject.com/)
+[![Python](https://img.shields.io/badge/python-3.11-blue.svg?logo=python)](https://www.python.org/)
+[![codecov](https://codecov.io/gh/THE-BWC/opserv/branch/main/graph/badge.svg?token=j4qIAObqWm)](https://codecov.io/gh/THE-BWC/opserv)
+[![pre-commit.ci status](https://results.pre-commit.ci/badge/github/THE-BWC/opserv/main.svg)](https://results.pre-commit.ci/latest/github/THE-BWC/opserv/main)
+[![CI](https://github.com/THE-BWC/opserv/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/THE-BWC/opserv/actions/workflows/ci.yml)
 
 [![Built with Cookiecutter Django](https://img.shields.io/badge/built%20with-Cookiecutter%20Django-ff69b4.svg?logo=cookiecutter)](https://github.com/cookiecutter/cookiecutter-django/)
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)

--- a/opserv/games/tests/factories.py
+++ b/opserv/games/tests/factories.py
@@ -7,7 +7,7 @@ from opserv.games.models import Game
 
 class GameFactory(DjangoModelFactory[Game]):
     name = Faker("name")
-    tag = Faker("word", length=10)
+    tag = Faker("bothify", text="????")
     icon = SimpleUploadedFile("icon.png", b"file_content", content_type="image/png")
 
     class Meta:

--- a/opserv/games/tests/factories.py
+++ b/opserv/games/tests/factories.py
@@ -7,7 +7,7 @@ from opserv.games.models import Game
 
 class GameFactory(DjangoModelFactory[Game]):
     name = Faker("name")
-    tag = Faker("word")
+    tag = Faker("word", length=10)
     icon = SimpleUploadedFile("icon.png", b"file_content", content_type="image/png")
 
     class Meta:

--- a/opserv/operations/tests/test_views.py
+++ b/opserv/operations/tests/test_views.py
@@ -3,30 +3,11 @@ from unittest.mock import patch
 
 import pytest
 from django.conf import settings
-from django.http import HttpResponseRedirect
 from django.urls import reverse
 
 from opserv.users.tests.factories import UserFactory
 
 pytestmark = pytest.mark.django_db
-
-
-class TestOperationsHomeView:
-    def test_operations_home_view(self, client):
-        response = client.get("/")
-        login_url = reverse(settings.LOGIN_URL)
-
-        assert isinstance(response, HttpResponseRedirect)
-        assert response.status_code == HTTPStatus.FOUND
-        assert response.url == login_url
-
-    def test_operations_home_view_authenticated(self, client):
-        user = UserFactory()
-        client.force_login(user)
-        response = client.get("/")
-
-        assert response.status_code == HTTPStatus.OK
-        assert "Welcome to the Operations Server" in str(response.content)
 
 
 class TestHomeView:
@@ -102,3 +83,9 @@ class TestHomeView:
         assert "Arma 3" in content
         assert "Operation Thunder" in content
         assert "Squad" in content
+
+    def test_base_html_page_block_rendered(self, client, user):
+        client.force_login(user)
+        response = client.get("/")
+        # Assert content from the 'page' block is present
+        assert b"Welcome to the Operations Server" in response.content

--- a/opserv/templates/base.html
+++ b/opserv/templates/base.html
@@ -43,8 +43,8 @@
   </head>
   <body class="{% block bodyclass %}{% endblock bodyclass %}">
     <!-- djlint:off -->
-        {% block page %}{% endblock page %}
-        {% block modal %}{% endblock modal %}
+            {% block page %}{% endblock page %}
+            {% block modal %}{% endblock modal %}
     <!-- djlint:on -->
     {% block inline_javascript %}
       {% comment %}

--- a/opserv/templates/base.html
+++ b/opserv/templates/base.html
@@ -42,10 +42,10 @@
     {% endblock javascript %}
   </head>
   <body class="{% block bodyclass %}{% endblock bodyclass %}">
-    <!-- djlint:off -->
-            {% block page %}{% endblock page %}
-            {% block modal %}{% endblock modal %}
-    <!-- djlint:on -->
+    {# djlint:off #}
+    {% block page %}{% endblock page %}
+    {% block modal %}{% endblock modal %}
+    {# djlint:on #}
     {% block inline_javascript %}
       {% comment %}
     Script tags with only code, no src (defer by default). To run

--- a/opserv/templates/base.html
+++ b/opserv/templates/base.html
@@ -42,10 +42,10 @@
     {% endblock javascript %}
   </head>
   <body class="{% block bodyclass %}{% endblock bodyclass %}">
-    {% block page %}
-    {% endblock page %}
-    {% block modal %}
-    {% endblock modal %}
+    <!-- djlint:off -->
+        {% block page %}{% endblock page %}
+        {% block modal %}{% endblock modal %}
+    <!-- djlint:on -->
     {% block inline_javascript %}
       {% comment %}
     Script tags with only code, no src (defer by default). To run


### PR DESCRIPTION
This pull request refactors the test suite for `opserv/operations/tests/test_views.py` and updates the `base.html` template to improve code readability and functionality. The most important changes include removing redundant tests, adding a new test for the `page` block rendering, and disabling linting for specific sections in the `base.html` template.

### Test suite improvements:
* [`opserv/operations/tests/test_views.py`](diffhunk://#diff-650170ccae0697d10d25a5625bed9b224c3d092fd7f3cf3db71058bbdcaa7b00L6-L31): Removed the `TestOperationsHomeView` class, including tests for unauthenticated and authenticated access to the operations home view, as they were redundant.
* [`opserv/operations/tests/test_views.py`](diffhunk://#diff-650170ccae0697d10d25a5625bed9b224c3d092fd7f3cf3db71058bbdcaa7b00R86-R91): Added a new test, `test_base_html_page_block_rendered`, to verify that the `page` block content is rendered correctly for authenticated users.

### Template updates:
* [`opserv/templates/base.html`](diffhunk://#diff-e6cf2290693cbd40d50a4dcbbe6141c9935ca5ed3f8be281622b87dbbc724583L45-R48): Disabled linting for the `page` and `modal` blocks using `djlint:off` and `djlint:on` comments to improve code readability and prevent unnecessary linting warnings.